### PR TITLE
Removed deprecated php versions and hhvm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+bin/
 /vendor/
 composer.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,17 @@
 language: php
 
 php:
-  - 5.3
-  - 5.4
-  - 5.5
   - 5.6
   - 7.0
-  - hhvm
+  - 7.1
 
 matrix:
   allow_failures:
-    - php: hhvm
-    - php: 7.0
+    - php: 7.1
 
 notifications:
   email:
-    - richard@waarneembemiddeling.nl
+    - development@waarneembemiddeling.nl
 
 before_script:
     - composer install

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "waarneembemiddeling/bigregister-soap",
-    "description": "php 5.3+ implementation of the Dutch BIG Register SOAP interface",
+    "description": "php 5.6+ implementation of the Dutch BIG Register SOAP interface",
     "keywords": ["BIG register", "BIG-register", "BIG-nummer", "bigregister.nl"],
     "license": "MIT",
     "authors": [
@@ -11,11 +11,15 @@
     ],
     "minimum-stability": "dev",
     "require": {
-        "ext-soap": "*",
+        "php": ">=5.6.0",
+        "ext-soap": ">=5.6.0",
         "doctrine/cache": ">=1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "3.7.*"
+        "phpunit/phpunit": "^5.6"
+    },
+    "config": {
+        "bin-dir": "bin"
     },
     "autoload": {
         "psr-0": {

--- a/src/Wb/BigRegister/SoapClient/Client.php
+++ b/src/Wb/BigRegister/SoapClient/Client.php
@@ -24,7 +24,7 @@ class Client extends BaseSoapClient
         $namespace = 'Wb\\BigRegister\\SoapClient\\Model\\';
         $options = array(
             'features'       => SOAP_SINGLE_ELEMENT_ARRAYS,
-            'cache_wsdl'     => WSDL_CACHE_BOTH,
+            'cache_wsdl'     => WSDL_CACHE_NONE,
             'classmap'       => array(
                 'ListHcpApproxRequest'                      => $namespace . 'ListHcpApproxRequest',
                 'ListHcpApproxResponse4'                    => $namespace . 'ListHcpApproxResponse4',

--- a/tests/Wb/Test/SoapClientTestCase.php
+++ b/tests/Wb/Test/SoapClientTestCase.php
@@ -8,15 +8,20 @@
 
 namespace Wb\Test;
 
-class SoapClientTestCase extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+use Wb\BigRegister\SoapClient\Client;
+
+class SoapClientTestCase extends TestCase
 {
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject|Client
+     */
     public function getSoapClient()
     {
-        $client = $this->getMock(
-            'Wb\BigRegister\SoapClient\Client',
-            array('__doRequest'),
-            array(__DIR__.'/../../../resources/bigregister.wsdl')
-        );
+        $client = $this->getMockBuilder(Client::class)
+            ->setMethods(['__doRequest'])
+            ->setConstructorArgs([__DIR__.'/../../../resources/bigregister.wsdl'])
+            ->getMock();
 
         $client->expects($this->any())
             ->method('__doRequest')


### PR DESCRIPTION
PHP versions 5.3, 5.4 and 5.5 are no longer supported
Removed testung on hhvm since it never worked
Upped the phpunit version and fixed SoapClientTestCase