### PR TITLE
Disabled wsdl cache causing segfaults (4.5 year old bug)

### DIFF
--- a/src/Wb/BigRegister/SoapClient/Client.php
+++ b/src/Wb/BigRegister/SoapClient/Client.php
@@ -24,7 +24,7 @@ class Client extends BaseSoapClient
         $namespace = 'Wb\\BigRegister\\SoapClient\\Model\\';
         $options = array(
             'features'       => SOAP_SINGLE_ELEMENT_ARRAYS,
-            'cache_wsdl'     => WSDL_CACHE_BOTH,
+            'cache_wsdl'     => WSDL_CACHE_NONE,
             'classmap'       => array(
                 'ListHcpApproxRequest'                      => $namespace . 'ListHcpApproxRequest',
                 'ListHcpApproxResponse4'                    => $namespace . 'ListHcpApproxResponse4',


### PR DESCRIPTION
This will solve errors in several php version @eriwin. Segfault is related to soap, using the wsdl cache causing segfaults in the php internal garbage collection.